### PR TITLE
Added module for remapping variants from HGVS to VCF format.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,3 @@ htmlcov
 # Complexity
 output/*.html
 output/*/index.html
-
-# Sphinx
-docs/_build

--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,61 @@ leiden_sc
 Tools for extracting, remapping, and validating variants from Leiden Open Variation Database Installations.
 
 * Free software: BSD license
-* Documentation: http://leiden_sc.rtfd.org.
+* Documentation: http://leiden_sc.rtfd.org. (Not Complete)
 
-Features
---------
+# Modules
 
-* TODO
+This project contains a number of number of modules within leiden_sc/:
+
+## lovd
+
+### macarthur_core/lovd/leiden_database.py:
+
+These classes allow a user to extract tables of data (mutations listed for a specific gene in the database) and other useful information from any Leiden Open Variation Database installation, such as http://www.dmd.nl/nmdb2/. Unfortunately, it has been necessary to do this by downloading the HTML for relevant pages on the database and parsing out the necessary data, as they do not have an easy way to access the data otherwise. Therefore, I have added an external dependency - beautifulsoup4 - for HTML parsing. 
+
+Basically, the usage for these classes goes like this:
+```
+leiden_url = 'http://www.dmd.nl/nmdb2/'
+gene_id = 'ACTA1'
+
+database = make_leiden_database(leiden_url)
+database.set_gene_id(gene_id)
+column_labels = leiden_database.get_table_headers()
+table_entries = leiden_database.get_table_data()
+...
+```
+Note that make_leiden_database acts as a factory method to generate the right subclass of LeidenDatabase for the detected version number. 
+
+### macarthur_core/lovd/utilities.py:
+
+These are general utility functions, some of which are used in leiden_database.py. 
+
+## remapping
+
+### macarthur_core/remapping/remapping.py
+
+Genetic mutations are often listed in one of two formats, HGVS and VCF. HGVS is compact and has its own (relatively complex) syntax for describing mutations. However, for large scale analysis projects HGVS is extremely difficult to use effectively for a number of reasons. We are interested in converting data from the Leiden Open Variation Databases from one format to the other. This is a non-trivial conversion. 
+
+The class ```VariantRemapper``` in ```macarthur_core/remapping/remapping.py``` wraps a third party module (hgvs) to make it easier to use within this project. The third party module documentation and description HGVS vs. VCF notation is described here: https://github.com/counsyl/hgvs
+
+Unfortunately, the third-party tool depends on two relatively large files that I cannot easily host on github. These are normally housed in a folder called resources within the module. One is a human genome reference sequence (```macarthur_core/remapping/resources/hg19.fa```) and the other is a file containing definitions of transcript sequences that are needed to facilitate conversion between the HGVS and VCF 
+(```macarthur_core/remapping/resources/genes.refSeq```). These two files are hosted at: http://www.broadinstitute.org/~ahill. Note that the files will need to decompressed using gunzip and placed in ```macarthur_core/remapping/resources/```. The first time these functions are used, two additional files will be generated (takes some time). Subsequent runs will not require this process to be repeated. 
+
+# Scripts
+
+I have included several scripts that I use to extract, remap, and validate data from LOVD databases. 
+
+## extract_data.py
+This is a script that I use in my overall project that makes use of the macarthur_core/lovd and macarthur_core/web_io to extract data from all data from a given LOVD URL. 
+
+The script makes use of argparse to provide a user interface. The string provided for the command-line interface should hopefully provide an explanation of how it is used. It should save a tab-delimited file for each gene's table data, where each output file is named according to the gene name.
+
+From command line generally it is used in the following way:
+```
+python extract_data.py --all --leiden_url http://www.dmd.nl/nmdb2/ --output_directory results
+```
+Users can also print a list of all available genes using:
+```
+python extract_data.py --genes_available --leiden_url http://www.dmd.nl/nmdb2/
+```
+

--- a/leiden_sc/macarthur_core/remapping/__init__.py
+++ b/leiden_sc/macarthur_core/remapping/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'Andrew Hill'

--- a/leiden_sc/macarthur_core/remapping/remapping.py
+++ b/leiden_sc/macarthur_core/remapping/remapping.py
@@ -1,0 +1,146 @@
+"""
+Andrew Hill
+MacArthur Lab - 2014
+
+Functions for handling remapping between HGVS and genomic coordinates.
+"""
+
+import hgvs
+import hgvs.utils
+from pygr.seqdb import SequenceFileDB
+import os
+import sys
+import re
+from macarthur_core.io import file_io
+from macarthur_core.lovd import utilities
+
+
+class VariantRemapper:
+    """
+    Class containing functions for remapping of variants from HGVS to genomic coordinate notation.
+    """
+
+    def __init__(self):
+        """
+        Initializes hg19 reference and reference transcripts
+        """
+
+        genome_path = os.path.join(os.path.dirname(__file__), 'resources', 'hg19.fa')
+        refseq_path = os.path.join(os.path.dirname(__file__), 'resources', 'genes.refGene')
+
+        # Read genome sequence using pygr.
+        self.genome = SequenceFileDB(genome_path)
+
+        # Read RefSeq transcripts into a python dict.
+        with open(refseq_path) as infile:
+            self.transcripts = hgvs.utils.read_transcripts(infile)
+
+    def hgvs_to_vcf(self, hgvs_variant):
+        """
+        Converts a single variant provided in HGVS notation to genomic coordinate notation.
+
+        See U(https://humgenprojects.lumc.nl/trac/mutalyzer/wiki/PositionConverter) for more information on acceptable
+        inputs and outputs, and remapping functionality.
+
+        @param hgvs_variant: HGVS description of variant, such as NM_001100.3:c.137T>C. The portion prior to the colon is
+        the refseqID used as the reference for the variant The portion after the colon is an HGVS-style description
+        of the mutation (a SNP from T to C at location 137 in the example above.
+        @type variant: string
+        @return: A tuple (chromosome_number, coordinate, ref, alt) in that order denoting the VCF notation of the variant
+        @rtype: tuple of strings
+        """
+
+        # Library requires string not unicode, ensure format is correct
+        hgvs_variant = str(hgvs_variant)
+
+        chromosome_number, coordinate, ref, alt = hgvs.parse_hgvs_name(hgvs_variant, self.genome, get_transcript=self._get_transcript)
+        chromosome_number = re.match('chr(.+)', chromosome_number).group(1)
+        coordinate = str(coordinate)
+
+        return chromosome_number, coordinate, ref, alt
+
+    def vcf_to_hgvs(self, reference_transcript, vcf_notation):
+        """
+        Converts a single VCF notation variant to HGVS notation relative to a given transcript.
+
+        @param reference_transcript: the refseq id of the reference transcript to use for HGVS notation
+        @type reference_transcript: string
+        @param vcf_notation: a tuple containing elements chromosome_number, coordinate, ref, and alt in that order
+        @type vcf_notation: tuple of strings
+        @return: hgvs notatation of variant in format reference_transcript:hgvs_description
+        @rtype: string
+        """
+
+        chromosome_number, coordinate, ref, alt = vcf_notation
+        coordinate = int(coordinate)
+
+        transcript = self._get_transcript(reference_transcript)
+
+        return hgvs.format_hgvs_name(chromosome_number, coordinate, ref, alt, self.genome, transcript)
+
+    def _get_transcript(self, name):
+        """
+        Callback to provide reference transcript by its name
+
+        @param name: name of reference transcript
+        @type name: string
+        @return: line of information on transcript from resource file
+        """
+        return self.transcripts.get(name)
+
+
+def generate_vcf_from_hgvs(input_file, output_file, hgvs_column, protein_change_column, column_delimiter='\t'):
+    """
+    Generate VCF files from files containing variants in HGVS notation. First row must contain column labels.
+
+    @param input_file: path to input file containing HGVS variants.
+    @type input_file: string
+    @param output_file: path to output file for VCF file
+    @type output_file: string
+    @param hgvs_column: column label for HGVS notation column
+    @type hgvs_column: string
+    @param protein_change_column: column label for predicted protein change column
+    @type protein_change_column: string
+    @param column_delimiter: column delimiter to use for input file
+    @type column_delimiter: string
+    @return: list of remapping error information. Each entry is [file, hgvs_notation, error].
+    @rtype: 2D list
+    """
+
+    remapper = VariantRemapper()
+    remapping_errors = []
+
+    table_data = file_io.read_table_from_file(input_file, column_delimiter=column_delimiter)
+    header = table_data.pop(0)
+
+    # Isolate data columns with HGVS mutations and protein change
+    hgvs_notation_index = utilities.find_string_index(header, hgvs_column)
+    hgvs_notation = []
+
+    protein_change_index = utilities.find_string_index(header, protein_change_column)
+    protein_change = []
+
+    # Remap Variants and build list for INFO column tags
+    vcf_notation_variants = []
+
+    for row in table_data:
+        try:
+            vcf_notation = remapper.hgvs_to_vcf(row[hgvs_notation_index])
+            vcf_notation_variants.append(vcf_notation)
+
+            hgvs_notation.append(row[hgvs_notation_index])
+            protein_change.append(row[protein_change_index])
+
+        except Exception as e:
+            remapping_errors.append([file, row[hgvs_notation_index], str(e)])
+
+    info_column_tags = {'HGVS': ('string', 'LOVD HGVS notation describing DNA change', hgvs_notation),
+            'LAA_CHANGE': ('string', 'LOVD amino acid change', protein_change)}
+
+    # Write VCF file
+    vcf_file_name = os.path.splitext(file)[0] + '.vcf'
+
+    vcf_file_text = file_io.format_vcf_text(vcf_notation_variants, info_column_tags)
+    file_io.write_table_to_file(vcf_file_name, vcf_file_text)
+
+    return remapping_errors


### PR DESCRIPTION
This code contains a new module macarthur_core/remapping. Genetic mutations are often listed in one of two formats, HGVS and VCF. HGVS is compact and has its own (relatively complex) syntax for describing mutations. However, for large scale analysis projects HGVS is extremely difficult to use effectively for a number of reasons. We want to convert data from the Leiden Open Variation Databases (the ones macarthur_core/lovd is designed to interact with) from one format to the other. This is a non-trivial conversion. 

The class VariantRemapper macarthur_core/remapping/remapping.py basically wraps a third party module to make it easier to use within my project. The third party module documentation and description HGVS vs. VCF notation is described here: https://github.com/counsyl/hgvs

Unfortunately, this module depends on two relatively large files that I cannot easily host on github. These are normally housed in a folder called resources within the module. One is a human genome reference sequence (hg19.fa) and the other is a file containing definitions of transcript sequences that are needed to facilitate conversion between the HGVS and VCF (genes.refSeq). If you would like to actually run the code, then we will need get you these files some other way.
