### PR TITLE
Added script that extracts all data tables from specified database.

### DIFF
--- a/leiden_sc/extract_data.py
+++ b/leiden_sc/extract_data.py
@@ -1,0 +1,132 @@
+"""
+Andrew Hill 
+MacArthur Lab - 2014
+
+Script that makes use of core LOVD module to extract variant data for different genes on any LOVD 2 or 3 database.
+
+For help, execute: python extract_data.py --help
+"""
+
+import argparse
+import os
+from collections import namedtuple
+from macarthur_core.io import file_io
+from macarthur_core.lovd.leiden_database import make_leiden_database
+from macarthur_core.remapping.remapping import VariantRemapper
+
+def extract_data(leiden_database, gene_id):
+    """
+    Extracts variant table data for given gene in leiden_database and submits variants for remapping to genomic coordinates.
+
+    @param leiden_database: database containing tables of variant data for specified gene_id
+    @type leiden_database: LeidenDatabase
+    @param gene_id: a string with the Gene ID of the gene to be extracted.
+    @type gene_id: string
+    @return: namedtuple containing remapping_batch_id_number, table_entries, and column_label entries.
+    @rtype: namedtuple
+    @raise: IOError if could not get data
+    """
+    try:
+        leiden_database.set_gene_id(gene_id)
+        column_labels = leiden_database.get_table_headers()
+        table_entries = leiden_database.get_table_data()
+
+    except Exception as e:
+        raise e
+
+    results = namedtuple('results', 'table_entries, column_labels')
+    return results(table_entries, column_labels)
+
+if __name__ == '__main__':
+    # Command line interface definition
+    parser = argparse.ArgumentParser(description='Given URL to the base URL of any LOVD 2 or 3 database installation, '
+                                                 'such as http://www.dmd.nl/nmdb2/, extract variant entries associated with '
+                                                 'specified genes. Can specify either a space-separated list of gene names '
+                                                 'or -a option to extract data from all genes at the specified URL. Variants '
+                                                 'for each gene are saved in a file named according to the gene name they '
+                                                 'are associated with.')
+
+    group1 = parser.add_mutually_exclusive_group()
+    group1.add_argument('-g', '--genes_available', action="store_true", help='Set to list of all available genes is printed. '
+                                                                            'No data is extracted or written to file.')
+    group1.add_argument('-a', '--all', default=False, action='store_true',
+                        help='Set to extract data for all available genes in the specified Leiden Database.')
+
+    parser.add_argument('-u', '--leiden_url', required=True, help='base URL of the particular Leiden database to be used. For example, '
+                                                   'the Leiden muscular dystrophy pages homepage is http://www.dmd.nl/nmdb2/. '
+                                                   'This must be a valid URL to base page of database. For example, '
+                                                   'http://databases.lovd.nl/whole_genome/ is a valid LOVD3 URL, while '
+                                                   'http://databases.lovd.nl/whole_genome/genes is not (it is not the base). '
+                                                   'A list of such acceptable URLs is maintained here: '
+                                                   'http://www.lovd.nl/2.0/index_list.php')
+
+    parser.add_argument('-l', '--gene_list', help='Gene ID or multiple gene_lists to retrieve from the Leiden Database.', nargs='*')
+
+    parser.add_argument('-o', '--output_directory', default='.', help='Output directory for saved files.')
+    args = parser.parse_args()
+
+    # Make the output directory if does not already exist
+    output_directory = args.output_directory
+
+    if not os.path.exists(output_directory):
+        os.mkdir(args.output_directory)
+
+    genes = None
+
+    if args.genes_available:
+        # Print list of available genes to the user
+        database = make_leiden_database(args.leiden_url)
+
+        print("\n".join(database.get_available_genes()))
+
+    else:
+        # Get database object and print the lovd version number
+        print("---> DETECTING LOVD VERSION: IN PROGRESS...")
+
+        # Use factory method to get LeidenDatabase object
+        database = make_leiden_database(args.leiden_url)
+        version_number = database.get_version_number()
+
+        print("---> DETECTING LOVD VERSION: COMPLETE")
+        print("    ---> VERSION " + str(version_number) + " DETECTED")
+
+        # User has specified the all option, extract data from all genes available on the Leiden Database
+        if args.all:
+            print("---> CHECKING AVAILABLE GENES...")
+            genes = database.get_available_genes()
+
+        else:
+            if len(args.gene_list) > 0:
+                genes = args.gene_list
+            else:
+                print('Must specify at least one gene_list.')
+
+
+        if genes:
+
+            print('---> Loading refSeq transcripts for remapping...')
+            remapper = VariantRemapper()
+
+            remapping_errors = []
+            variant_entries_found = False
+
+            # Extract data and output VCF and raw data for each gene
+            for gene in genes:
+                print '---> ' + gene + ': IN PROGRESS...'
+                print '    ---> Downloading data...'
+
+                # Extract table data
+                try:
+                    table_data, column_labels = extract_data(database, gene)
+                    variant_entries_found = True
+                except ValueError as e:
+                    print '    ---> ' + str(e)
+                    variant_entries_found = False
+
+            print '    ---> Saving raw data...'
+            table_data.insert(0, column_labels)
+            output_file_name = os.path.join(output_directory, gene + '.txt')
+
+            file_io.write_table_to_file(output_file_name, table_data)
+
+            print('---> All genes complete.')

--- a/leiden_sc/extract_data.py
+++ b/leiden_sc/extract_data.py
@@ -16,13 +16,13 @@ from macarthur_core.remapping.remapping import VariantRemapper
 
 def extract_data(leiden_database, gene_id):
     """
-    Extracts variant table data for given gene in leiden_database and submits variants for remapping to genomic coordinates.
+    Extracts variant table data for given gene in leiden_database.
 
     @param leiden_database: database containing tables of variant data for specified gene_id
     @type leiden_database: LeidenDatabase
     @param gene_id: a string with the Gene ID of the gene to be extracted.
     @type gene_id: string
-    @return: namedtuple containing remapping_batch_id_number, table_entries, and column_label entries.
+    @return: namedtuple containing table entries and column labels.
     @rtype: namedtuple
     @raise: IOError if could not get data
     """

--- a/leiden_sc/extract_data.py
+++ b/leiden_sc/extract_data.py
@@ -12,7 +12,6 @@ import os
 from collections import namedtuple
 from macarthur_core.io import file_io
 from macarthur_core.lovd.leiden_database import make_leiden_database
-from macarthur_core.remapping.remapping import VariantRemapper
 
 def extract_data(leiden_database, gene_id):
     """
@@ -101,32 +100,22 @@ if __name__ == '__main__':
             else:
                 print('Must specify at least one gene_list.')
 
-
         if genes:
 
-            print('---> Loading refSeq transcripts for remapping...')
-            remapper = VariantRemapper()
-
-            remapping_errors = []
-            variant_entries_found = False
-
-            # Extract data and output VCF and raw data for each gene
             for gene in genes:
                 print '---> ' + gene + ': IN PROGRESS...'
                 print '    ---> Downloading data...'
 
-                # Extract table data
+                # Extract table data and save to file
                 try:
                     table_data, column_labels = extract_data(database, gene)
-                    variant_entries_found = True
+
+                    print '    ---> Saving raw data...'
+                    table_data.insert(0, column_labels)
+                    output_file_name = os.path.join(output_directory, gene + '.txt')
+
+                    file_io.write_table_to_file(output_file_name, table_data)
                 except ValueError as e:
                     print '    ---> ' + str(e)
-                    variant_entries_found = False
-
-            print '    ---> Saving raw data...'
-            table_data.insert(0, column_labels)
-            output_file_name = os.path.join(output_directory, gene + '.txt')
-
-            file_io.write_table_to_file(output_file_name, table_data)
 
             print('---> All genes complete.')

--- a/leiden_sc/extract_data.py
+++ b/leiden_sc/extract_data.py
@@ -9,7 +9,6 @@ For help, execute: python extract_data.py --help
 
 import argparse
 import os
-from collections import namedtuple
 from macarthur_core.io import file_io
 from macarthur_core.lovd.leiden_database import make_leiden_database
 
@@ -21,10 +20,11 @@ def extract_data(leiden_database, gene_id):
     @type leiden_database: LeidenDatabase
     @param gene_id: a string with the Gene ID of the gene to be extracted.
     @type gene_id: string
-    @return: namedtuple containing table entries and column labels.
-    @rtype: namedtuple
+    @return: tuple containing table entries, column labels.
+    @rtype: tuple containing 2D list and list respectively
     @raise: IOError if could not get data
     """
+    
     try:
         leiden_database.set_gene_id(gene_id)
         column_labels = leiden_database.get_table_headers()
@@ -33,8 +33,7 @@ def extract_data(leiden_database, gene_id):
     except Exception as e:
         raise e
 
-    results = namedtuple('results', 'table_entries, column_labels')
-    return results(table_entries, column_labels)
+    return table_entries, column_labels
 
 if __name__ == '__main__':
     # Command line interface definition

--- a/leiden_sc/macarthur_core/lovd/leiden_database.py
+++ b/leiden_sc/macarthur_core/lovd/leiden_database.py
@@ -276,7 +276,7 @@ class LeidenDatabase:
         results = m.search(self.database_soup.get_text())
 
         # Return entire matched sequence (PMID)
-        if results is not None:
+        if results:
             return int(results.group(1))
         else:
             raise ValueError('No entries found at given URL')

--- a/leiden_sc/macarthur_core/lovd/leiden_database.py
+++ b/leiden_sc/macarthur_core/lovd/leiden_database.py
@@ -141,7 +141,7 @@ class LeidenDatabase:
         @rtype: string
         """
 
-        raise Exception("ABSTRACT METHOD NOT IMPLEMENTED")
+        raise NotImplementedError("ABSTRACT METHOD NOT IMPLEMENTED")
 
     def get_gene_homepage_url(self):
         """
@@ -152,7 +152,7 @@ class LeidenDatabase:
         @rtype: string
         """
 
-        raise Exception("ABSTRACT METHOD NOT IMPLEMENTED")
+        raise NotImplementedError("ABSTRACT METHOD NOT IMPLEMENTED")
 
     def get_available_genes(self):
         """
@@ -163,7 +163,7 @@ class LeidenDatabase:
         @rtype: string
         """
 
-        raise Exception("ABSTRACT METHOD NOT IMPLEMENTED")
+        raise NotImplementedError("ABSTRACT METHOD NOT IMPLEMENTED")
 
     def get_link_urls(self, link_result_set):
         """
@@ -221,7 +221,7 @@ class LeidenDatabase:
         labels are found.
         """
 
-        raise Exception("ABSTRACT METHOD NOT IMPLEMENTED")
+        raise NotImplementedError("ABSTRACT METHOD NOT IMPLEMENTED")
 
     def get_table_data(self):
         """
@@ -258,7 +258,7 @@ class LeidenDatabase:
         @rtype: 2D list of strings (1st dimension is rows, 2nd is columns)
         """
 
-        raise Exception("ABSTRACT METHOD NOT IMPLEMENTED")
+        raise NotImplementedError("ABSTRACT METHOD NOT IMPLEMENTED")
 
     def get_total_variant_count(self):
         """

--- a/leiden_sc/macarthur_core/lovd/utilities.py
+++ b/leiden_sc/macarthur_core/lovd/utilities.py
@@ -27,7 +27,7 @@ def get_pmid(link_url):
     results = m.search(link_url)
 
     # Return entire matched sequence (PMID)
-    if results is not None:
+    if results:
         return results.group()
     else:
         raise ValueError('Input URL did not contain 4+ digit number.')
@@ -53,7 +53,7 @@ def get_omimid(link_url):
     results = m.search(link_url)
 
     # Return entire matched sequence (OMIM ID)
-    if results is not None:
+    if results:
         return results.group()
     else:
         raise ValueError('Input URL did not contain valid OMIM ID.')


### PR DESCRIPTION
This is a script that I use in my overall project that makes use of the macarthur_core/lovd and macarthur_core/web_io to extract data from all data from a given LOVD URL. 

The script makes use of argparse to provide a user interface. The string provided for the command-line interface should hopefully provide an explanation of how it is used. It should save a tab-delimited file for each gene's table data, where each output file is named according to the gene name.

From command line generally it is used in the following way:

```
python extract_data.py --all --leiden_url http://www.dmd.nl/nmdb2/ --output_directory results
```

Users can also print a list of all available genes using:

```
python extract_data.py --genes_available --leiden_url http://www.dmd.nl/nmdb2/
```
