### PR TITLE
Added file_io module and updated README to reflect addition.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,16 @@ The class ```VariantRemapper``` in ```macarthur_core/remapping/remapping.py``` w
 Unfortunately, the third-party tool depends on two relatively large files that I cannot easily host on github. These are normally housed in a folder called resources within the module. One is a human genome reference sequence (```macarthur_core/remapping/resources/hg19.fa```) and the other is a file containing definitions of transcript sequences that are needed to facilitate conversion between the HGVS and VCF 
 (```macarthur_core/remapping/resources/genes.refSeq```). These two files are hosted at: http://www.broadinstitute.org/~ahill. Note that the files will need to decompressed using gunzip and placed in ```macarthur_core/remapping/resources/```. The first time these functions are used, two additional files will be generated (takes some time). Subsequent runs will not require this process to be repeated. 
 
+## io
+
+### macarthur_core/io/file_io.py
+This module has functions for reading and writing delimited files to and from 2D lists where first dimension is rows and
+the second is columns. It also contains a function for formatting output text for a file format called <a href='http://www.1000genomes.org/wiki/Analysis/Variant%20Call%20Format/vcf-variant-call-format-version-41'>VCF</a> from a 2D
+list of data.
+
+### macarthur_core/io/web_io.py
+This module has functions for reading HTML data from URLs.
+
 # Scripts
 
 I have included several scripts that I use to extract, remap, and validate data from LOVD databases. 

--- a/leiden_sc/macarthur_core/io/file_io.py
+++ b/leiden_sc/macarthur_core/io/file_io.py
@@ -1,0 +1,102 @@
+"""
+Andrew Hill
+MacArthur Lab - 2014
+
+Functions for handling file data input and output.
+"""
+
+
+def format_vcf_text(vcf_format_variants, info_column_entries):
+    """
+    Create formatted VCF file data from remapped variants.
+
+    @param vcf_format_variants: list of tuples that contain chromosome_number, coordinate, ref, alt in that order
+    @type: list of tuples of strings
+    @param info_column_entries: dictionary where keys are tags to place in info column. The values are tuples that
+    contain data_type, description, and a list of values (one per entry in vcf_format_variant)
+    @type info_column_entries: dict
+    @return: list of lists where each inner list is a row of the VCF file, and each element in the inner list represents
+    the value of the respective column in a given row.
+    @rtype: list of lists
+    """
+
+    # Initialize with required header information for the VCF input to Variant Effect Predictor
+    vcf_text = [
+        ['##fileformat=VCFv4.0'],
+        ['#CHROM', 'POS', 'ID', 'REF', 'ALT', 'QUAL', 'FILTER', 'INFO']
+    ]
+
+    # Insert INFO tag descriptions into VCF header
+    tag_keys = info_column_entries.keys()
+
+    for tag in tag_keys:
+        tag_header_text = ''.join(['##INFO=<ID=', tag, ',Number=1,Type=', info_column_entries[tag][0], ',Description="', info_column_entries[tag][1], '">'])
+        vcf_text.insert(1, [tag_header_text])
+
+    # Format VCF body text
+    for i in range(0, len(vcf_format_variants)):
+
+        chromosome_number, coordinate, ref, alt = vcf_format_variants[i]
+
+        list_of_tags = []
+        for tag in tag_keys:
+            list_of_tags.append(tag + '=' + info_column_entries[tag][2][i])
+
+        vcf_file_row = [chromosome_number,
+                        coordinate,
+                        '.',
+                        ref,
+                        alt, '.',
+                        '.',
+                        ';'.join(list_of_tags)]
+
+        vcf_text.append(vcf_file_row)
+
+    return vcf_text
+
+
+def read_table_from_file(file_name, column_delimiter='\t'):
+    """
+    Returns table of data from tab-delimited file. Alternate delimiter can be specified.
+
+    @param file_name: path to tab-delimited file wit
+    @type file_name: string
+    @param column_delimiter: column delimiter (tab by default)
+    @type column_delimiter: string
+    @return:table of data from tab-delimited file
+    @rtype: 2D list of strings (1st dimension is rows, 2nd is columns)
+    """
+
+    with open(file_name, 'r') as f:
+        file_text = f.read().splitlines()
+
+    return [line.split('\t') for line in file_text]
+
+
+def write_table_to_file(file_name, table, column_delimiter='\t'):
+    """
+    Writes table to tab-delimited file. Alternate delimiter can be specified.
+
+    @param file_name: name of output file with extension (can include path)
+    @type file_name: string
+    @param column_delimiter: column delimiter (tab by default)
+    @type column_delimiter: string
+    @param table: table data to output to file
+    @type table: 2D list of strings (1st dimension is rows, 2nd is columns)
+    """
+
+    row_delimiter = '\n'
+
+    file_lines = []
+
+    for row in table:
+        file_lines.append(column_delimiter.join(row))
+
+    output_text = row_delimiter.join(file_lines)
+
+    # Ensure unicode strings are encoded before writing
+    if isinstance(output_text, unicode):
+        output_text = output_text.encode('utf-8')
+
+    with open(file_name, 'w') as f:
+        f.write(output_text)


### PR DESCRIPTION
This additional module has functions for reading and writing delimited files to and from 2D lists where first dimension is rows and the second is columns. It also contains a function for formatting output text for a file format called <a href='http://www.1000genomes.org/wiki/Analysis/Variant%20Call%20Format/vcf-variant-call-format-version-41'>VCF</a> from a 2D list. This format is one of the current standard file formats within genomics, and is required for input to third-party tools used in this project and many others in the lab.
